### PR TITLE
stepper set directions only on dualx unpark

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -28,9 +28,11 @@
 
 #define RAPIDIA_PROTOCOL 2
 
-// #define RAPIDIA_NO_HOTENDS
-// #define RAPIDIA_NO_EXTRUDE
-// #define RAPIDIA_NO_HEATED_BED
+#ifdef RAPIDIA_DRY
+  #define RAPIDIA_NO_HOTENDS
+  #define RAPIDIA_NO_EXTRUDE
+  #define RAPIDIA_NO_HEATED_BED
+#endif
 
 #ifndef RAPIDIA_PLASTIC
     #define RAPIDIA_METAL
@@ -928,6 +930,8 @@
 #ifdef RAPIDIA_METAL
   #define NOZZLE_AS_PROBE
 #endif
+
+#define RAPIDIA_ALWAYS_SET_DIRECTIONS
 
 /**
  * Z Servo Probe, such as an endstop switch on a rotating arm.

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1012,8 +1012,6 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
                   line_to_current_position(planner.settings.max_feedrate_mm_s[Z_AXIS]);
           delayed_move_time = 0;
           active_extruder_parked = false;
-          planner.synchronize();
-          stepper.set_directions();
           if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clear active_extruder_parked");
           break;
         case DXC_MIRRORED_MODE:
@@ -1029,7 +1027,6 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
             planner.set_position_mm(inactive_extruder_x_pos, current_position.y, current_position.z, current_position.e);
             if (!planner.buffer_line(new_pos, planner.settings.max_feedrate_mm_s[X_AXIS], 1)) break;
             planner.synchronize();
-            stepper.set_directions();
             sync_plan_position();
             extruder_duplication_enabled = true;
             active_extruder_parked = false;
@@ -1039,6 +1036,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
           break;
       }
     }
+    
     return false;
   }
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1012,6 +1012,8 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
                   line_to_current_position(planner.settings.max_feedrate_mm_s[Z_AXIS]);
           delayed_move_time = 0;
           active_extruder_parked = false;
+          planner.synchronize();
+          stepper.set_directions();
           if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clear active_extruder_parked");
           break;
         case DXC_MIRRORED_MODE:
@@ -1027,6 +1029,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
             planner.set_position_mm(inactive_extruder_x_pos, current_position.y, current_position.z, current_position.e);
             if (!planner.buffer_line(new_pos, planner.settings.max_feedrate_mm_s[X_AXIS], 1)) break;
             planner.synchronize();
+            stepper.set_directions();
             sync_plan_position();
             extruder_duplication_enabled = true;
             active_extruder_parked = false;
@@ -1036,7 +1039,6 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
           break;
       }
     }
-    stepper.set_directions();
     return false;
   }
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2160,6 +2160,7 @@ uint32_t Stepper::block_phase_isr() {
       if ( ENABLED(HAS_L64XX)  // Always set direction for L64xx (Also enables the chips)
         || current_block->direction_bits != last_direction_bits
         || TERN(MIXING_EXTRUDER, false, stepper_extruder != last_moved_extruder)
+        || ENABLED(RAPIDIA_ALWAYS_SET_DIRECTIONS)
       ) {
         last_direction_bits = current_block->direction_bits;
         #if EXTRUDERS > 1

--- a/platformio.ini
+++ b/platformio.ini
@@ -433,6 +433,18 @@ lib_deps          = ${common.lib_deps}
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
+# Rapidia Dry (Plastic, but without hotends or extrusion)
+#
+[env:rapidia_dry]
+build_flags       = ${common.build_flags} -DRAPIDIA_PLASTIC -DRAPIDIA_DRY
+platform          = atmelavr
+board             = megaatmega2560
+board_build.f_cpu = 16000000L
+lib_deps          = ${common.lib_deps}
+  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+
+#
 # Rapidia Arduino
 #
 [env:rapidia_arduino]


### PR DESCRIPTION
### Description

dualx unpark routine now only sets stepper directions when an actual unpark occurs.

### Benefits

This may fix the sudden layer shift issue.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/19151