### PR TITLE
Stepper hang fix

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1997,25 +1997,28 @@ uint32_t Stepper::block_phase_isr() {
       while (true)
       {
         if (TEST(current_block->flag, BLOCK_BIT_SYNC_POSITION)) {
+          // sync block
           _set_position(current_block->position);
           discard_current_block();
-
-          continue;
         }
         else if (current_block->step_event_count == 0) {
-          // ignore
+          // empty block -- ignore this block
           discard_current_block();
-
-          continue;
         }
         else
         {
+          // this block is good; we can stop searching for a block.
           break;
         }
 
-        // get a new block
-        if (!(current_block = planner.get_current_block()))
-            return interval; // No more queued movements!
+        // get a new block.
+        current_block = planner.get_current_block();
+
+        if (!current_block)
+        {
+          // No more queued movements!
+          return interval;
+        }
       }
 
       // For non-inline cutter, grossly apply power

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2000,12 +2000,12 @@ uint32_t Stepper::block_phase_isr() {
         // so we must replace it and try another.
         discard_current_block();
         current_block = planner.get_current_block();
+      }
 
-        if (!current_block)
-        {
-          // No more queued movements, so we cannot proceed.
-          return interval;
-        }
+      if (!current_block)
+      {
+        // the planning queue is empty, so we cannot proceed.
+        return interval;
       }
 
       // For non-inline cutter, grossly apply power
@@ -2612,12 +2612,15 @@ void Stepper::init() {
   #endif
 }
 
-// returns false if block is a standard motion block
+// returns false if block is a standard motion block or nullptr.
 // returns true and has side-effects otherwise.
-// block must not be null.
 FORCE_INLINE bool Stepper::handle_non_motion_block(const block_t* block)
 {
-  if (TEST(block->flag, BLOCK_BIT_SYNC_POSITION)) {
+  if (!block)
+  {
+    return false;
+  }
+  else if (TEST(block->flag, BLOCK_BIT_SYNC_POSITION)) {
     // this is a sync block
     _set_position(block->position);
     return true;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1990,10 +1990,6 @@ uint32_t Stepper::block_phase_isr() {
   // and prepare its movement
   if (!current_block) {
 
-    // FIXME: why is this called twice here?
-    // (note that function is not necessarily idempotent even in ISR context)
-    current_block = planner.get_current_block();
-
     // Anything in the buffer?
     if (current_block = planner.get_current_block()) {
 

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -528,6 +528,8 @@ class Stepper {
 
   private:
 
+    static bool handle_non_motion_block(const block_t* block);
+
     // Set the current position in steps
     static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
     FORCE_INLINE static void _set_position(const abce_long_t &spos) { _set_position(spos.a, spos.b, spos.c, spos.e); }


### PR DESCRIPTION
### Description

Cleans up the loop that pops the next block in the planner ISR.

### Benefits

Loop no longer can hang forever, and also it is easier to maintain now.

### Configurations

(configuration file matches 2.0.6.1r)