### PR TITLE
M112 shutdown even when busy

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1050,6 +1050,8 @@
  *     O-- FRONT --+
  */
 
+#define RAPIDIA
+
 #ifdef RAPIDIA_PLASTIC
   #define NOZZLE_TO_PROBE_OFFSET { 10, 10, 0 }
 #else

--- a/Marlin/src/HAL/AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/AVR/MarlinSerial.cpp
@@ -714,6 +714,10 @@
   // Hookup ISR handlers
   ISR(SERIAL_REGNAME(USART,SERIAL_PORT,_RX_vect)) {
     MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>::store_rxd_char();
+
+    #if ENABLED(RAPIDIA_EMERGENCY_STOP_INTERRUPT)
+      MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>::_on_rx_isr_end();
+    #endif
   }
 
   ISR(SERIAL_REGNAME(USART,SERIAL_PORT,_UDRE_vect)) {

--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -207,6 +207,10 @@
     FORCE_INLINE static void store_rxd_char();
     FORCE_INLINE static void _tx_udr_empty_irq();
 
+    #if ENABLED(RAPIDIA_EMERGENCY_STOP_INTERRUPT)
+      static void _on_rx_isr_end();
+    #endif
+
     public:
       MarlinSerial() {};
       static void begin(const long);

--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -41,4 +41,16 @@ bool EmergencyParser::killed_by_M112, // = false
 // Global instance
 EmergencyParser emergency_parser;
 
+#if ENABLED(RAPIDIA_EMERGENCY_STOP_INTERRUPT)
+template<>
+void MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>::_on_rx_isr_end()
+{
+  // callback for when killed by m112.
+  if (EmergencyParser::killed_by_M112)
+  {
+    EmergencyParser::on_killed_by_m112();
+  }
+}
+#endif
+
 #endif // EMERGENCY_PARSER

--- a/Marlin/src/feature/e_parser.h
+++ b/Marlin/src/feature/e_parser.h
@@ -99,6 +99,8 @@ public:
 
   FORCE_INLINE static void disable() { enabled = false; }
 
+  static void on_killed_by_m112();
+
   FORCE_INLINE static void update(State &state, const uint8_t c) {
 
     #if ENABLED(RAPIDIA_DEBUG)

--- a/Marlin/src/gcode/rapidia/dev/dev_R800_R801.cpp
+++ b/Marlin/src/gcode/rapidia/dev/dev_R800_R801.cpp
@@ -8,6 +8,15 @@ static volatile bool softlock = false;
 void GcodeSuite::R800()
 {
     const bool do_cli = (parser.seenval('I') ? parser.value_byte() : 0);
+    const bool do_wdr = (parser.seenval('W') ? parser.value_byte() : 0);
+
+    const char* p = parser.string_arg;
+    for (int i = 0; i < 2; ++i)
+    {
+        if (p[0] == 'I') p += 2;
+        if (p[0] == 'W') p += 2;
+        while (p[0] == ' ') ++p;
+    }
 
     if (do_cli)
     {
@@ -15,7 +24,18 @@ void GcodeSuite::R800()
     }
 
     softlock = true;
-    while (softlock);
+    while (softlock)
+    {
+        if (p[0])
+        {
+            SERIAL_ECHOLN(p);
+        }
+
+        if (do_wdr)
+        {
+            watchdog_refresh();
+        }
+    }
     
     if (!do_cli)
     {

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -603,7 +603,9 @@ void CardReader::openFileWrite(char * const path) {
     if (file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)) {
       flag.saving = true;
       selectFileByName(fname);
-      TERN_(EMERGENCY_PARSER, emergency_parser.disable());
+      #if DISABLED(RAPIDIA)
+        TERN_(EMERGENCY_PARSER, emergency_parser.disable());
+      #endif
       echo_write_to_file(fname);
       ui.set_status(fname);
     }
@@ -708,7 +710,9 @@ void CardReader::closefile(const bool store_location) {
   file.close();
   flag.saving = flag.logging = false;
   sdpos = 0;
-  TERN_(EMERGENCY_PARSER, emergency_parser.enable());
+  #if DISABLED(RAPIDIA)
+    TERN_(EMERGENCY_PARSER, emergency_parser.enable());
+  #endif
 
   if (store_location) {
     //future: store printer state, filename and position for continuing a stopped print


### PR DESCRIPTION
## Details

Modified `M112: emergency shutdown` emergency parsing to jump to `kill()` immediately rather than wait until the next idle loop to kill. This means even if the printer is busy or stuck (e.g. `R800: infinite loop`) it will shut down.

## Testing Done

- started an infinite loop (`R800`, or `R800 W1` to prevent watchdog from restarting the printer during the loop)
- then shut down printer using `M112`
- then reset using `R750`.

## Testing required:

Try the above experiment on a metal printer and check that the heaters and steppers shut off after `M112` (but before `R750`).