### PR TITLE
R740: check for USB device

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1863,9 +1863,7 @@
  * you must uncomment the following option or it won't work.
  *
  */
-#if DISABLED(ARDUINO_MODE)
-  #define SDSUPPORT
-#endif
+#define SDSUPPORT
 
 /**
  * SD CARD: SPI SPEED

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1259,7 +1259,7 @@
    *
    * [1] On AVR an interrupt-capable pin is best for UHS3 compatibility.
    */
-  // #define USB_FLASH_DRIVE_SUPPORT
+  #define USB_FLASH_DRIVE_SUPPORT
   #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
     #define USB_CS_PIN    SDSS
     #define USB_INTR_PIN  SD_DETECT_PIN

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -997,6 +997,10 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
         #endif
         case 735: R735(); break;                                  // R735: z-max hysteresis threshold
       #endif
+
+      #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
+        case 740: R740(); break;                                  // R740: check for usb flash drive
+      #endif
       
       #if ENABLED(RAPIDIA_LAMP_ALIAS)
         case 736: M106(); break;                                  // R736: alias for M106

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -839,6 +839,8 @@ private:
     // M737  --  alias for M107
   #endif
 
+  TERN_(USB_FLASH_DRIVE_SUPPORT, static void R740()); // check for usb flash drive
+
   #if ENABLED(RAPIDIA_KILL_RECOVERY)
     // R750 -- handled in emergency parser.
   #endif

--- a/Marlin/src/gcode/rapidia/R740.cpp
+++ b/Marlin/src/gcode/rapidia/R740.cpp
@@ -1,0 +1,20 @@
+#include "../../inc/MarlinConfig.h"
+
+#include "../gcode.h"
+#include "../../sd/SdVolume.h"
+#include "../../MarlinCore.h"
+
+#if ENABLED(USB_FLASH_DRIVE_SUPPORT)
+
+void GcodeSuite::R740()
+{
+    Sd2Card::usbStartup();
+
+    // delay for 500 ms to allow sd card setup
+    // (done in idle()).
+    const millis_t time = millis() + 500;
+    while (PENDING(millis(), time)) idle();
+}
+
+#endif // USB_FLASH_DRIVE_SUPPORT
+

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Directly pulses various pins. This will cause the firmware to forget which pins 
 Lamp on/Lamp off.
 For now, these commands are aliases of M106 and M107.
 
+### R740
+
+Check for USB shield.
+
+This command can be used to try checking for a connected USB device if
+Marlin previously failed to detect it on init.
+
 ### R750
 
 Hard Reset.


### PR DESCRIPTION
### Background

When `USB_FLASH_DRIVE_SUPPORT` is enabled, but no USB shield is attached, Marlin spams error messages about not being able to connect to the USB shield.

### Description

This PR causes Marlin to give up trying to initialize the USB host after the first instance of the failure which causes the aforementioned error message to be printed out. It also adds the command `R740` which causes Marlin to attempt to connect to the USB shield again. (If Marlin is already successfully connected to the USB shield, R740 has no effect.)

### Testing performed

- On an arduino with no USB shield, only one instance of the error message is printed out.
- When R740 is sent to that arduino, the error message is printed out once more (because it attempts to connect and fails)

### Testing needed

- Ensure that an Arduino which is connected to a USB shield functions as normal (in particular, the MUX still works as it did previously without any additional R740 commands needed to retry the connection.)
- (Bonus points) Check that an arduino which is not connected to a USB shield on startup but is later connected to the USB shield is able to function with USB support only after R740 is sent to the arduino.